### PR TITLE
Fix issues identified while building for Debian

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,7 +101,6 @@ def setup(app):
 html_logo = "_static/img/rti-logo.png"
 html_favicon = "_static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/plugins/adapters/kafka/doc/conf.py
+++ b/plugins/adapters/kafka/doc/conf.py
@@ -100,7 +100,6 @@ def setup(app):
 html_logo = "_static/img/rti-logo.png"
 html_favicon = "_static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/plugins/adapters/mqtt/doc/conf.py
+++ b/plugins/adapters/mqtt/doc/conf.py
@@ -94,7 +94,7 @@ html_theme = 'sphinx_rtd_theme'
 
 def setup(app):
     app.add_css_file('theme_overrides.css')
-    app.add_js_file('custom.js')
+    # app.add_js_file('custom.js')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/plugins/processors/fwd/doc/conf.py
+++ b/plugins/processors/fwd/doc/conf.py
@@ -100,7 +100,6 @@ def setup(app):
 html_logo = "_static/img/rti-logo.png"
 html_favicon = "_static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/plugins/transformations/field/doc/conf.py
+++ b/plugins/transformations/field/doc/conf.py
@@ -100,7 +100,6 @@ def setup(app):
 html_logo = "static/img/rti-logo.png"
 html_favicon = "static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/plugins/transformations/json/doc/conf.py
+++ b/plugins/transformations/json/doc/conf.py
@@ -100,7 +100,6 @@ def setup(app):
 html_logo = "static/img/rti-logo.png"
 html_favicon = "static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/plugins/transformations/sequence2array/doc/conf.py
+++ b/plugins/transformations/sequence2array/doc/conf.py
@@ -100,7 +100,6 @@ def setup(app):
 html_logo = "static/img/rti-logo.png"
 html_favicon = "static/img/favicon.ico"
 html_css_files = ['css/custom.css']
-html_js_files = ['js/custom.js']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/resource/cmake/ConfigureThirdPartyBuilds.cmake
+++ b/resource/cmake/ConfigureThirdPartyBuilds.cmake
@@ -69,7 +69,7 @@ macro (rtigw_configure_rd_kafka_build)
     set(RDKAFKA_BUILD_TESTS              FALSE
         CACHE INTERNAL "Enable building RD Kafka's sample programs"
         FORCE)
-    set(WITH_BUNDLED_SSL ${RTIGATEWAY_ENABLE_SSL}
+    set(WITH_BUNDLED_SSL FALSE
         CACHE INTERNAL "Enable building RD Kafka with OpenSSL support"
         FORCE)
     set(WITH_SSL ${RTIGATEWAY_ENABLE_SSL}


### PR DESCRIPTION
While trying to bundle the Gateway into a Debian package, I noticed a few things that should be fixed, and I'm opening this PR to keep track of them and propose fixes.

## Disable WITH_BUNDLED_SSL option for RDKafka

The build fails to configure when OpenSSL support is enabled.

The reason is that option `WITH_BUNDLED_SSL` is currently set to `TRUE` if `RTIGATEWAY_ENABLE_SSL`, which causes `rdkafka` to look for a target named `bundled-ssl` which is not defined.

This PR sets option `WITH_BUNDLED_SSL` to be always `FALSE`.

## Update documented default values for CMake options

The documentation for various CMake options seems to be inconsistent with their actual default values. For example, `RTIGATEWAY_ENABLE_DOCS` is reported to be `ON` by default, but that is not the case.