### PR TITLE
Added <climits> to fix missing CHAR_MAX/MIN error

### DIFF
--- a/common/utils/srcCxx/UtilsLongDouble.hpp
+++ b/common/utils/srcCxx/UtilsLongDouble.hpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <climits>
 
 namespace rti { namespace utils { namespace long_double {
 


### PR DESCRIPTION
Hi,
I found a compilation error when building the project using:

- cmake version 3.16.3
- g++ (Ubuntu 9.4.0-1ubuntu1-20.04.2) 9.4.0
- gcc (Ubuntu 9.4.0-1ubuntu1-20.04.2) 9.4.0

This fix solves the issue.

`error: 'CHAR_MAX' was not declared in this scope`